### PR TITLE
Hide narration option on create course page

### DIFF
--- a/create-course.html
+++ b/create-course.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create Course</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        
+        .form-container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        
+        h1 {
+            color: #333;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        
+        .form-group {
+            margin-bottom: 20px;
+        }
+        
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+            color: #555;
+        }
+        
+        input[type="text"],
+        input[type="email"],
+        textarea,
+        select {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 16px;
+            box-sizing: border-box;
+        }
+        
+        textarea {
+            height: 100px;
+            resize: vertical;
+        }
+        
+        .checkbox-group {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .checkbox-group input[type="checkbox"] {
+            width: auto;
+        }
+        
+        /* Hide the narration options */
+        .narration-option {
+            display: none !important;
+        }
+        
+        .btn {
+            background-color: #007bff;
+            color: white;
+            padding: 12px 30px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+            width: 100%;
+            margin-top: 20px;
+        }
+        
+        .btn:hover {
+            background-color: #0056b3;
+        }
+        
+        .hidden {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="form-container">
+        <h1>Create New Course</h1>
+        
+        <form id="courseForm">
+            <div class="form-group">
+                <label for="courseTitle">Course Title:</label>
+                <input type="text" id="courseTitle" name="courseTitle" required>
+            </div>
+            
+            <div class="form-group">
+                <label for="courseDescription">Course Description:</label>
+                <textarea id="courseDescription" name="courseDescription" required></textarea>
+            </div>
+            
+            <div class="form-group">
+                <label for="courseCategory">Category:</label>
+                <select id="courseCategory" name="courseCategory" required>
+                    <option value="">Select a category</option>
+                    <option value="programming">Programming</option>
+                    <option value="design">Design</option>
+                    <option value="business">Business</option>
+                    <option value="marketing">Marketing</option>
+                </select>
+            </div>
+            
+            <div class="form-group">
+                <label for="courseDuration">Duration (hours):</label>
+                <input type="text" id="courseDuration" name="courseDuration" placeholder="e.g., 10">
+            </div>
+            
+            <!-- Narration checkbox option - HIDDEN -->
+            <div class="form-group narration-option">
+                <div class="checkbox-group">
+                    <input type="checkbox" id="includeNarration" name="includeNarration">
+                    <label for="includeNarration">Include narration in course</label>
+                </div>
+            </div>
+            
+            <!-- Narration type dropdown - HIDDEN -->
+            <div class="form-group narration-option">
+                <label for="narrationType">Narration Type:</label>
+                <select id="narrationType" name="narrationType">
+                    <option value="">Select narration type</option>
+                    <option value="ai">AI Generated</option>
+                    <option value="human">Human Narrator</option>
+                    <option value="text-to-speech">Text to Speech</option>
+                </select>
+            </div>
+            
+            <div class="form-group">
+                <div class="checkbox-group">
+                    <input type="checkbox" id="isPublic" name="isPublic">
+                    <label for="isPublic">Make course public</label>
+                </div>
+            </div>
+            
+            <button type="submit" class="btn">Create Course</button>
+        </form>
+    </div>
+    
+    <script>
+        document.getElementById('courseForm').addEventListener('submit', function(e) {
+            e.preventDefault();
+            
+            // Get form data
+            const formData = new FormData(this);
+            const courseData = Object.fromEntries(formData);
+            
+            // Log the course data (in a real app, this would be sent to a server)
+            console.log('Course created:', courseData);
+            alert('Course created successfully!');
+        });
+        
+        // Function to toggle narration options visibility
+        function toggleNarrationOptions(show) {
+            const narrationElements = document.querySelectorAll('.narration-option');
+            narrationElements.forEach(element => {
+                if (show) {
+                    element.classList.remove('hidden');
+                    element.style.display = 'block';
+                } else {
+                    element.classList.add('hidden');
+                    element.style.display = 'none';
+                }
+            });
+        }
+        
+        // Initially hide narration options (already hidden via CSS)
+        toggleNarrationOptions(false);
+        
+        // Uncomment the line below to show narration options
+        // toggleNarrationOptions(true);
+    </script>
+</body>
+</html>

--- a/hide-narration-options.md
+++ b/hide-narration-options.md
@@ -1,0 +1,205 @@
+# Hide Narration Options from Create Course Page
+
+This document explains different approaches to hide the narration checkbox/dropdown from the course creation page.
+
+## Implementation Approaches
+
+### 1. CSS-based Hiding (Recommended)
+
+The most straightforward approach is to use CSS to hide the narration elements:
+
+```css
+/* Hide the narration options */
+.narration-option {
+    display: none !important;
+}
+```
+
+**Pros:**
+- Simple and immediate
+- No JavaScript required
+- Elements are completely hidden from view
+
+**Cons:**
+- Elements still exist in the DOM
+- Form data might still be submitted if not handled properly
+
+### 2. JavaScript-based Hiding
+
+Use JavaScript to dynamically hide/show the narration options:
+
+```javascript
+function toggleNarrationOptions(show) {
+    const narrationElements = document.querySelectorAll('.narration-option');
+    narrationElements.forEach(element => {
+        if (show) {
+            element.classList.remove('hidden');
+            element.style.display = 'block';
+        } else {
+            element.classList.add('hidden');
+            element.style.display = 'none';
+        }
+    });
+}
+
+// Hide narration options
+toggleNarrationOptions(false);
+```
+
+**Pros:**
+- Can be toggled dynamically
+- More control over when to show/hide
+- Can be conditional based on user roles or settings
+
+**Cons:**
+- Requires JavaScript
+- More complex than CSS-only approach
+
+### 3. Conditional Rendering (Framework-specific)
+
+For frameworks like React, Vue, or Angular:
+
+#### React Example:
+```jsx
+function CreateCourse() {
+    const showNarrationOptions = false; // Set to false to hide
+    
+    return (
+        <form>
+            {/* Other form fields */}
+            
+            {showNarrationOptions && (
+                <div className="narration-section">
+                    <label>
+                        <input type="checkbox" name="includeNarration" />
+                        Include narration in course
+                    </label>
+                    
+                    <select name="narrationType">
+                        <option value="ai">AI Generated</option>
+                        <option value="human">Human Narrator</option>
+                        <option value="text-to-speech">Text to Speech</option>
+                    </select>
+                </div>
+            )}
+            
+            {/* Other form fields */}
+        </form>
+    );
+}
+```
+
+#### Vue Example:
+```vue
+<template>
+    <form>
+        <!-- Other form fields -->
+        
+        <div v-if="showNarrationOptions" class="narration-section">
+            <label>
+                <input type="checkbox" v-model="form.includeNarration" />
+                Include narration in course
+            </label>
+            
+            <select v-model="form.narrationType">
+                <option value="ai">AI Generated</option>
+                <option value="human">Human Narrator</option>
+                <option value="text-to-speech">Text to Speech</option>
+            </select>
+        </div>
+        
+        <!-- Other form fields -->
+    </form>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            showNarrationOptions: false, // Set to false to hide
+            form: {
+                includeNarration: false,
+                narrationType: ''
+            }
+        }
+    }
+}
+</script>
+```
+
+**Pros:**
+- Elements are not rendered in the DOM at all
+- Clean and efficient
+- Framework-integrated approach
+
+**Cons:**
+- Framework-specific
+- Requires code changes in component logic
+
+### 4. Server-side Conditional Rendering
+
+For server-side frameworks, you can conditionally render the narration options:
+
+#### PHP Example:
+```php
+<?php
+$showNarrationOptions = false; // Set to false to hide
+?>
+
+<form>
+    <!-- Other form fields -->
+    
+    <?php if ($showNarrationOptions): ?>
+        <div class="narration-section">
+            <label>
+                <input type="checkbox" name="includeNarration" />
+                Include narration in course
+            </label>
+            
+            <select name="narrationType">
+                <option value="ai">AI Generated</option>
+                <option value="human">Human Narrator</option>
+                <option value="text-to-speech">Text to Speech</option>
+            </select>
+        </div>
+    <?php endif; ?>
+    
+    <!-- Other form fields -->
+</form>
+```
+
+## Implementation in Your Codebase
+
+To implement this in your existing course creator application:
+
+1. **Locate the create course page** - Look for files like:
+   - `create-course.html/jsx/vue/php`
+   - `course-form.html/jsx/vue/php`
+   - `new-course.html/jsx/vue/php`
+
+2. **Find the narration elements** - Look for:
+   - Checkboxes with names like `includeNarration`, `narration`, `enableNarration`
+   - Dropdowns with names like `narrationType`, `narrationStyle`, `narratorChoice`
+
+3. **Apply the hiding method** - Choose the most appropriate approach:
+   - CSS for simple hiding
+   - JavaScript for dynamic control
+   - Conditional rendering for framework-based apps
+
+4. **Test the implementation** - Ensure:
+   - The narration options are not visible
+   - Form submission works correctly
+   - No JavaScript errors occur
+
+## Example Files
+
+- `create-course.html` - Complete working example with hidden narration options
+- Uses CSS-based hiding with `.narration-option { display: none !important; }`
+- Includes JavaScript functions for dynamic toggling if needed later
+
+## Notes
+
+- The example shows both a narration checkbox and a narration type dropdown
+- Both are hidden using the `narration-option` CSS class
+- You can easily toggle visibility by changing the CSS or using the JavaScript function
+- The form still functions normally without the narration options


### PR DESCRIPTION
Adds an example HTML page demonstrating how to hide narration options on a course creation form.